### PR TITLE
First go at using empymod for Hankel DLF

### DIFF
--- a/simpegEM1D/EM1DSimulation.py
+++ b/simpegEM1D/EM1DSimulation.py
@@ -83,7 +83,7 @@ def run_simulation_FD(args):
     # This is hard-wired at the moment
     expmap = Maps.ExpMap(mesh_1d)
     prob = EM1D(
-        mesh_1d, sigmaMap=expmap, filter_type='key_101'
+        mesh_1d, sigmaMap=expmap, hankel_filter='key_101_2009'
     )
     if prob.ispaired:
         prob.unpair()
@@ -154,7 +154,7 @@ def run_simulation_TD(args):
     # This is hard-wired at the moment
     expmap = Maps.ExpMap(mesh_1d)
     prob = EM1D(
-        mesh_1d, sigmaMap=expmap, filter_type='key_101'
+        mesh_1d, sigmaMap=expmap, hankel_filter='key_101_2009'
     )
     if prob.ispaired:
         prob.unpair()


### PR DESCRIPTION
This is a first go to use `empymod` for the Hankel DLF.

- Only implemented at the moment for `output_type == 'response'`.
- Set-up so that you can use any Hankel filter provided in `empymod.filters`.
- I got a couple of question to your implementation of the Hankel DLF, you can find them easily by searching for `??? D.W.`
- I started to implement it in a way that should make it easily afterwards to permit for Lagged Convolution or Splined DLF, by having a `pts_per_dec`-parameter.

I did test it on `simpegEM1D/notebooks/examples/EM1D_fwd.ipynb`, but not more, so I won't guarantee it works smoothly. Specifically related to the question I have for `CircularLoop` and `piecewise_line`, where I am not so sure about your normalization of the wavenumber-points calculation and the DLF result (`r y`, `a`).