### PR TITLE
Provide interpolated points to dlf

### DIFF
--- a/simpegEM1D/EM1D.py
+++ b/simpegEM1D/EM1D.py
@@ -280,7 +280,8 @@ class EM1D(Problem.BaseProblem):
 
         # Use function from empymod
         # size of lambd is (n_frequency x n_filter)
-        lambd, _ = get_spline_values(self.fhtfilt, r, self.hankel_pts_per_dec)
+        lambd, int_pts = get_spline_values(self.fhtfilt, r,
+                                           self.hankel_pts_per_dec)
         n_filter = self.n_filter
         # TODO: potentially store
         f = np.tile(self.survey.frequency.reshape([-1, 1]), (1, n_filter))
@@ -412,7 +413,7 @@ class EM1D(Problem.BaseProblem):
         # HzFHT size = (n_layer, n_frequency)
 
         HzFHT = dlf(PJ, lambd, r, self.fhtfilt, self.hankel_pts_per_dec,
-                    factAng=None, ab=33)
+                    factAng=None, ab=33, int_pts=int_pts)
 
         if output_type == "sensitivity_sigma":
             return HzFHT.T


### PR DESCRIPTION
@sgkang , that is one of the resulting outcomes of our discussion today. It is now possible to provide the interpolated points to the `dlf`, so you save one call to `get_spline_values` (the one in `empymod.dlf`, not here).

However, this is only available in the dev-branch of empymod, so you better wait a bit with this pull request until the next version of empymod is released.

This would have the biggest impact if you loop over frequencies, specifically in time-domain calculations, where you need a lot of frequencies, but the offsets and therefore `lambd` and `int_pts` stay the same. But I think you do all frequencies at once, so the impact might actually be almost nil. Still thought it might be worth it.